### PR TITLE
Handle when timescale values aren't set in world data

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -99,7 +99,12 @@ end
 
 function Weather.getTimerDuration()
     local roll = Weather.getRandom()
-    local frametimeMultiplier = WorldInstance.data.time.timeScale / WorldInstance.defaultTimeScale
+    if WorldInstance.data.time.dayTimeScale ~= nil and WorldInstance.data.time.nightTimeScale ~= nil then
+       local frametimeMultiplier = ((WorldInstance.data.time.dayTimeScale + WorldInstance.data.time.nightTimeScale)
+             / 2) / WorldInstance.defaultTimeScale
+    else
+        local frametimeMultiplier = WorldInstance.defaultTimeScale
+    end
     local hours = Weather.config.minDuration + (Weather.config.maxDuration - Weather.config.minDuration) * roll
     return hours * frametimeMultiplier * 60 * 1000
 end


### PR DESCRIPTION
By default, a newly created world won't have any timescale data in
world.json.  That also appears to now be represented by day and night
values.

getTimerDuration now first tests for thes values, and if they exist
an average value is used to divide against the world default timescale
value.

If no timescale values exist for either day or night, whatever is
returned by WorldInstance.defaultTimeScale will be used.